### PR TITLE
feat: print receipt fix, Upstash keep-alive cron, and dev loading UX

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,13 +88,15 @@
       let publicKey;
       let paymentConfig;
 
-      // Detect environment immediately from hostname — no backend call needed
+      // Detect environment immediately from hostname — no backend call needed.
+      // Production hostname is scc-donations.vercel.app; all other .vercel.app
+      // hostnames are preview deployments.
       const hostname = window.location.hostname;
       if (hostname === 'localhost' || hostname === '127.0.0.1') {
         environmentLabel.textContent = 'Development Environment';
         environmentLabel.classList.remove('hidden', 'bg-yellow-200', 'text-yellow-800');
         environmentLabel.classList.add('bg-blue-200', 'text-blue-800');
-      } else if (hostname.endsWith('.vercel.app')) {
+      } else if (hostname.endsWith('.vercel.app') && hostname !== 'scc-donations.vercel.app') {
         environmentLabel.textContent = 'Preview Environment';
         environmentLabel.classList.remove('hidden');
       }


### PR DESCRIPTION
## Summary

- **Print fix:** thank-you page receipt now fits on a single letter-sized page
  (replaced narrow 80mm receipt layout with full-page print CSS, tighter
  spacing, and 0.5in page margins)
- **Upstash keep-alive:** added `/api/cron-ping` endpoint (protected by
  `CRON_SECRET`) and Vercel Cron schedule (Mondays noon UTC) to keep the
  free-tier Redis database active without manual test transactions
- **Dev loading UX:** environment badge (Preview/Development) now appears
  instantly from `window.location.hostname` rather than waiting for the backend
  config fetch; donate button shows "Loading payment system..." during cold start
- **Legal language:** restored full donation purpose statement and tax
  deductibility notice to the thank-you receipt
- **Bug fix:** production hostname excluded from preview environment badge
  detection (both prod and preview were on `.vercel.app`)

## Manual Vercel step completed
- `CRON_SECRET` environment variable added to Production in Vercel dashboard

## Test plan
- [x] Print preview of thank-you page fits on one page with full legal text
- [x] Preview environment badge appears immediately on page load
- [x] Production deployment shows no environment badge
- [x] Donate button shows loading state then enables correctly
- [x] End-to-end donation transaction tested on preview — passed
- [ ] Confirm cron job appears in Vercel dashboard → Cron Jobs tab